### PR TITLE
Argumentos de entrada via linha de comando e exibição dos conjuntos de entrada/saída

### DIFF
--- a/input_program.py
+++ b/input_program.py
@@ -13,17 +13,18 @@ def arg_input() -> tuple:
     # Entrada de parâmetros via terminal
     argument_list = sys.argv[1:]
 
-    options = "p:c:"
+    options = "p:c:rl"
 
-    long_options = ["programa=", "csv_palavras="]
+    long_options = ["programa=", "csv_palavras=", "rejeita", "lista"]
 
     prog_path = ""
     csv_path = ""
+    arg_rejeita = False
+    arg_lista = False
 
     ## Parsing dos argumentos e valores atribuídos
     try:
         arguments, values = getopt.getopt(argument_list, options, long_options)
-        print(arguments, values)
 
     except getopt.error as err:
         print(str(err))
@@ -34,17 +35,22 @@ def arg_input() -> tuple:
 
         if current_argument in ("-p", "--programa"):
             prog_path = current_value
-            print("Arquivo de programa:", prog_path)
+            print("\nArquivo de programa:", prog_path)
 
         elif current_argument in ("-c", "--csv_palavras"):
             if (re.search(r'\.csv$', current_value)):
                 print("Arquivo .csv de Palavras:", current_value)
             else:
                 raise Exception("O arquivo de palavras deve ser um arquivo .csv")
-            
             csv_path = current_value
 
-    return prog_path, csv_path
+        elif current_argument in ("-r", "--rejeita"):
+            arg_rejeita = True
+
+        elif current_argument in ("-l", "--lista"):
+            arg_lista = True
+
+    return prog_path, csv_path, arg_rejeita, arg_lista
 
 def ler_set_de_string(string_set):
     # Remove as chaves e espaços desnecessários

--- a/main.py
+++ b/main.py
@@ -27,18 +27,34 @@ class AFN:
         return any(estado in self.estados_aceita for estado in estados_atuais)
 
 def main():
-    programa_path, palavras_csv_path = arg_input()
+    print("\n////////////////////////////////////////////////////")
+    print("AFN->AFD para reconhecimento de sintaxe URI")
+    print("Leonardo Azzi Martins e Dennis Pereira Krigger")
+    print("////////////////////////////////////////////////////")
+
+    programa_path, palavras_csv_path, opt_lista_rejeita, opt_lista_palavras = arg_input()
     
     estados, alfabeto, transicoes, estado_inicial, estados_finais = leitura(programa_path)
 
     nfa = AFN(estados, alfabeto, transicoes, estado_inicial, estados_finais)
 
-    print(programa_path, palavras_csv_path)
-
     palavras = leituraCSV(palavras_csv_path)
 
+    if (opt_lista_palavras):
+        print("\nPalavras de entrada:")
+        for palavra in palavras:
+            print('\t', palavra)
+
+    if (opt_lista_rejeita):
+        print("\nPalavras do conjunto REJEITA:")
+        for palavra in palavras:
+            if (nfa.aceita(palavra) == False):
+                print('\t', palavra)
+
+    print("\nPalavras do conjunto ACEITA:")
     for palavra in palavras:
-        print(palavra, ' ', nfa.aceita(palavra))
+        if (nfa.aceita(palavra)):
+            print('\t', palavra)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
 - Implementa parsing de argumentos na linha de comando, para passar mais rapidamente os parâmetros necessários ao programa. Exemplo:
` python3 main.py -p entrada -c listadepalavras.csv -l -r`
onde:
-p: caminho do programa de entrada
-c: caminho do .csv com a lista de palavras
-l: opção para exibir no terminal a lista de palavras completa
-r: opção para exibir a lista de palavras rejeitadas pelo AF
- Exibe sempre o conjunto ACEITA no terminal para um programa válido